### PR TITLE
Add topic configuration to fssim-custom-metrics

### DIFF
--- a/fssim-custom-metrics/config.yaml
+++ b/fssim-custom-metrics/config.yaml
@@ -12,14 +12,14 @@ rules:
   fssim-custom-metrics:
     plugin: "rbb_tools.plugins.fssim_custom_metrics"
     config:
+      topics:
         fssim_topic_track: "/fssim/track"
         fssim_topic_markers: "/fssim/track/markers"
         fssim_topic_gt_pose: "/fssim/base_pose_ground_truth"
         jarvic_topic_slam: "/est/slam/state"
         jarvic_topic_slam_map: "/est/slam/map"
         jarvic_topic_loc_state: "/est/localization/state"
-        # TODO: change back to /planning/trajectory
-        jarvic_topic_trajectory: "/test/planning/trajectory"
+        jarvic_topic_trajectory: "/planning/trajectory"
     topic_matchers:
       - type: "rbb_tools.extraction.matchers.AllTopicsMatchingRule"
         config:

--- a/fssim-custom-metrics/config.yaml
+++ b/fssim-custom-metrics/config.yaml
@@ -13,12 +13,15 @@ rules:
     plugin: "rbb_tools.plugins.fssim_custom_metrics"
     config:
       topics:
-        fssim_topic_track: "/fssim/track"
-        fssim_topic_markers: "/fssim/track/markers"
+        fssim_topic_cone_collision: "/fssim/collisions"
         fssim_topic_gt_pose: "/fssim/base_pose_ground_truth"
-        jarvic_topic_slam: "/est/slam/state"
-        jarvic_topic_slam_map: "/est/slam/map"
+        fssim_topic_lap_info: "/fssim/lap_info"
+        fssim_topic_leaving_track: "/fssim/leaving_track"
+        fssim_topic_markers: "/fssim/track/markers"
+        fssim_topic_track: "/fssim/track"
         jarvic_topic_loc_state: "/est/localization/state"
+        jarvic_topic_slam_map: "/est/slam/map"
+        jarvic_topic_slam: "/est/slam/state"
         jarvic_topic_trajectory: "/planning/trajectory"
     topic_matchers:
       - type: "rbb_tools.extraction.matchers.AllTopicsMatchingRule"

--- a/fssim-custom-metrics/config.yaml
+++ b/fssim-custom-metrics/config.yaml
@@ -12,6 +12,14 @@ rules:
   fssim-custom-metrics:
     plugin: "rbb_tools.plugins.fssim_custom_metrics"
     config:
+        fssim_topic_track: "/fssim/track"
+        fssim_topic_markers: "/fssim/track/markers"
+        fssim_topic_gt_pose: "/fssim/base_pose_ground_truth"
+        jarvic_topic_slam: "/est/slam/state"
+        jarvic_topic_slam_map: "/est/slam/map"
+        jarvic_topic_loc_state: "/est/localization/state"
+        # TODO: change back to /planning/trajectory
+        jarvic_topic_trajectory: "/test/planning/trajectory"
     topic_matchers:
       - type: "rbb_tools.extraction.matchers.AllTopicsMatchingRule"
         config:


### PR DESCRIPTION
This PR adds the configuration that is needed for https://gitlab.fachschaften.org/get-racing/driverless/rosbag-bazaar/rbb-core/-/merge_requests/14

It is possible to merge  it independentls of the MR on gitlab, as there is a default config in place in the code.